### PR TITLE
feat: activate Jest coverage thresholds to prevent quality regression (#112)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,15 +17,15 @@ export default {
     '!src/index.js', // Main entry file
   ],
 
-  // Coverage thresholds (will be activated when we have tests)
-  // coverageThreshold: {
-  //   global: {
-  //     branches: 80,
-  //     functions: 80,
-  //     lines: 80,
-  //     statements: 80
-  //   }
-  // },
+  // Coverage thresholds - activated to prevent quality regression
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 95,
+      lines: 95,
+      statements: 95,
+    },
+  },
 
   // Coverage reports
   coverageReporters: ['text', 'lcov', 'html', 'json-summary'],


### PR DESCRIPTION
## Summary
Activates coverage thresholds in Jest configuration to prevent quality regression as requested in #112.

## Implementation Details
- Activated `coverageThreshold` in `jest.config.js` with conservative but effective values:
  - **branches**: 90% (based on current 98.81% global coverage)
  - **functions**: 95% (based on current 99.35% global coverage)  
  - **lines**: 95% (based on current 99.69% global coverage)
  - **statements**: 95% (based on current 99.7% global coverage)

## Testing
- ✅ All 707 tests pass
- ✅ Coverage thresholds validated and working
- ✅ Quality gates (lint, format, coverage) all passing
- ✅ Pre-commit and pre-push hooks functioning correctly

## Technical Decision
Chose conservative thresholds that are below current coverage levels to:
1. **Prevent regression** without being overly restrictive
2. **Allow realistic development workflow** for future implementations
3. **Account for edge cases** in legacy files with slightly lower coverage

## Validation
The thresholds are actively enforced and will fail CI if coverage drops below:
- 90% branch coverage (currently at 98.81%)
- 95% function/line/statement coverage (currently at 99%+)

Closes #112